### PR TITLE
Fix profile save index check

### DIFF
--- a/alpha-pi/src/components/biz-owners/Dashboard.jsx
+++ b/alpha-pi/src/components/biz-owners/Dashboard.jsx
@@ -94,7 +94,7 @@ const Dashboard = () => {
     const handleSave = (e) => {
         e.preventDefault();
 
-        if (users[index] !== -1) {
+        if (index !== -1) {
             users[index] = {
                 ...users[index],
                 nameOfBiz,


### PR DESCRIPTION
## Summary
- fix dashboard profile save logic to verify index instead of user object

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d6a92ac70832c93bb5285f326c7f4