### PR TITLE
Add jest test for PasswordValidator

### DIFF
--- a/alpha-pi/package.json
+++ b/alpha-pi/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "react": "^19.1.0",

--- a/alpha-pi/src/components/utils/__tests__/PasswordValidator.test.js
+++ b/alpha-pi/src/components/utils/__tests__/PasswordValidator.test.js
@@ -1,0 +1,14 @@
+import PasswordValidator from '../PasswordValidator.js';
+
+describe('PasswordValidator', () => {
+  test('valid passwords return true', () => {
+    expect(PasswordValidator('abc12345')).toBe(true);
+    expect(PasswordValidator('A1b2C3d4')).toBe(true);
+  });
+
+  test('invalid passwords return false', () => {
+    expect(PasswordValidator('abcdefg')).toBe(false); // too short
+    expect(PasswordValidator('abcdefgh')).toBe(false); // no digits
+    expect(PasswordValidator('12345678')).toBe(false); // no letters
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for PasswordValidator util
- enable `npm test` by adding a Jest script

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d6bbeb348832c95db3df3ba3a486f