### PR TITLE
Refactor news page with real API data

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,14 @@ The Netlify configuration is stored in `alpha-pi/netlify.toml`.
    npm install
    ```
 
-2. Run the development server:
+2. Create a `.env` file and provide a GNews API key:
+
+   ```bash
+   cp .env.example .env
+   # edit .env and set VITE_GNEWS_API_KEY
+   ```
+
+3. Run the development server:
 
    ```bash
    npm run dev
@@ -45,7 +52,7 @@ The Netlify configuration is stored in `alpha-pi/netlify.toml`.
 
    Vite will start the app on [http://localhost:5173](http://localhost:5173).
 
-3. Build for production:
+4. Build for production:
 
    ```bash
    npm run build
@@ -57,7 +64,7 @@ The Netlify configuration is stored in `alpha-pi/netlify.toml`.
    npm run preview
    ```
 
-4. Lint the project:
+5. Lint the project:
 
    ```bash
    npm run lint

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The Netlify configuration is stored in `alpha-pi/netlify.toml`.
 
    ```bash
    cp .env.example .env
-   # edit .env and set VITE_GNEWS_API_KEY
+   # open the file and replace "your_api_key_here" with your real key
    ```
 
 3. Run the development server:

--- a/alpha-pi/.env.example
+++ b/alpha-pi/.env.example
@@ -1,0 +1,1 @@
+VITE_GNEWS_API_KEY=your_api_key_here

--- a/alpha-pi/src/components/News.jsx
+++ b/alpha-pi/src/components/News.jsx
@@ -1,33 +1,56 @@
-import data from "../data/NewsData.json"
-import Footer from "./Footer";
-import Header from "./Header";
+import { useEffect, useState } from "react"
+import backupData from "../data/NewsData.json"
+import Footer from "./Footer"
+import Header from "./Header"
 import "./News.css"
 
+const API_URL = `https://gnews.io/api/v4/search?q=small%20business&lang=en&token=${import.meta.env.VITE_GNEWS_API_KEY}`
+
 const News = () => {
+    const [ articles, setArticles ] = useState([])
+
+    useEffect(() => {
+        const fetchNews = async () => {
+            try {
+                const res = await fetch(API_URL)
+                if (!res.ok) throw new Error('Failed to fetch')
+                const json = await res.json()
+                if (json.articles) {
+                    setArticles(json.articles)
+                } else {
+                    setArticles(backupData)
+                }
+            } catch (_) {
+                setArticles(backupData)
+            }
+        }
+
+        fetchNews()
+    }, [])
+
     return (
         <div className="wrapper">
             <Header />
 
             <main className="news-main">
                 <h1>News:</h1>
-                
+
                 <div className="news-layout">
-                    {data.map((news) => (
-                        <a href={news.link} target="_blank" rel="noopener noreferrer">
+                    {articles.map((news, index) => (
+                        <a key={index} href={news.url || news.link} target="_blank" rel="noopener noreferrer">
                             <button className="news-btn">
                                 <div className="news-btn-content">
-                                    <h5>{news.company}</h5>
+                                    <h5>{news.source?.name || news.company}</h5>
                                     <p>{news.title}</p>
                                 </div>
                             </button>
-                        </a>                    
+                        </a>
                     ))}
                 </div>
             </main>
 
             <Footer />
         </div>
-    );
+    )
 }
- 
-export default News;
+ export default News;

--- a/alpha-pi/src/components/News.jsx
+++ b/alpha-pi/src/components/News.jsx
@@ -4,13 +4,19 @@ import Footer from "./Footer"
 import Header from "./Header"
 import "./News.css"
 
-const API_URL = `https://gnews.io/api/v4/search?q=small%20business&lang=en&token=${import.meta.env.VITE_GNEWS_API_KEY}`
-
 const News = () => {
     const [ articles, setArticles ] = useState([])
 
     useEffect(() => {
         const fetchNews = async () => {
+            const apiKey = import.meta.env.VITE_GNEWS_API_KEY
+            if (!apiKey) {
+                setArticles(backupData)
+                return
+            }
+
+            const API_URL = `https://gnews.io/api/v4/search?q=small%20business&lang=en&token=${apiKey}`
+
             try {
                 const res = await fetch(API_URL)
                 if (!res.ok) throw new Error('Failed to fetch')
@@ -52,5 +58,4 @@ const News = () => {
             <Footer />
         </div>
     )
-}
- export default News;
+}export default News;


### PR DESCRIPTION
## Summary
- refactor News component to fetch data from the GNews API
- add `.env.example` with placeholder API key
- update README with env instructions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d744dad60832cb2e196019593ea68